### PR TITLE
feat: Implement repository interfaces and classes for League, Conference, Division, Team, Player, and generic operations

### DIFF
--- a/GenericRepository.md
+++ b/GenericRepository.md
@@ -1,0 +1,121 @@
+# `GenericRepository`
+
+## Overview
+The `GenericRepository<T>` class is a generic implementation of the repository pattern, which provides a way to manage data access and manipulation for different entities in a consistent manner. It abstracts the underlying data access technology (Entity Framework Core) and provides a set of common methods for CRUD operations.
+
+## Features
+- Type-safe data access through generics
+- Support for both hard and soft deletion
+- Asynchronous operations with cancellation token support
+- Comprehensive logging
+- Flexible querying with predicates
+- Eager loading of related entities
+- Pagination support
+- Optional tracking control for better performance
+
+## Key Methods
+
+### Basic CRUD Operations
+- `GetAllAsync()` - Retrieves all records of the entity type
+- `GetByIdAsync(int id)` - Retrieves a specific entity by its ID
+- `AddAsync(T entity)` - Adds a new entity to the database
+- `UpdateAsync(T entity)` - Updates an existing entity
+- `DeleteAsync(int id)` - Deletes an entity (supports soft deletion if entity implements ISoftDeletable)
+
+### Advanced Querying
+- `FindAsync(Expression<Func<T, bool>> predicate)` - Finds entities matching a condition
+- `GetByPredicateAsync(Expression<Func<T, bool>> predicate)` - Retrieves entities based on a predicate
+- `GetByPredicateAsync(Expression<Func<T, bool>> predicate, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy, int skip, int take, ...)` - Advanced querying with ordering and pagination
+
+#### Key Points About `GetByPredicateAsync`:
+- **Predicate**: A function that defines the condition to filter entities.
+- **OrderBy**: An optional function to specify the ordering of the results.
+- **Skip**: Number of records to skip (for pagination).
+- **Take**: Number of records to take (for pagination).
+- **CancellationToken**: Allows for cancellation of the operation, useful in long-running queries.
+- **Tracking**: Optionally control whether the returned entities are tracked by the context.
+- **Include**: Specify related entities to include in the query (eager loading).
+- **AsNoTracking**: Optionally disable change tracking for better performance when the entities are not modified.
+
+
+## Usage Example
+
+- How to use `GetByPredicateAsync` to find players by team ID:
+
+```csharp
+// Example usage in a service or controller
+public class PlayerService
+{
+    private readonly IGenericRepository<Player> _playerRepository;
+
+    public PlayerService(IGenericRepository<Player> playerRepository)
+    {
+        _playerRepository = playerRepository;
+    }
+
+    public async Task<IEnumerable<Player>> GetPlayersByTeamIdAsync(int teamId, CancellationToken cancellationToken)
+    {
+        // Create the predicate to filter players by team ID
+        Expression<Func<Player, bool>> teamPredicate = player => player.TeamId == teamId;
+
+        // Use the repository method to find players
+        return await _playerRepository.GetByPredicateAsync(
+            teamPredicate,
+            orderBy: players => players.OrderBy(p => p.Name), // Optional ordering
+            skip: 0, // No skipping for this example
+            take: 10, // Limit to 10 players
+            cancellationToken: cancellationToken // Pass the cancellation token
+        );
+    }
+}
+```
+
+- Could also use `return await _playerRepository.GetByPredicateAsync(teamPredicate);` to get all players without pagination.
+
+1. The method takes a LINQ expression that defines your filtering condition.
+2. You can create more complex predicates:
+
+```csharp
+// Find active players in a specific team
+Expression<Func<Player, bool>> activePlayers = player => player.TeamId == teamId && player.IsActive = true;
+
+// Find players by position in a team
+Expression<Func<Player, bool>> goalkeepers = player => player.TeamId == teamId && player.Position == "Goalkeeper";
+```
+
+3. If you need to include related data or order results, use one of the overloads:
+
+```csharp
+// Including related data and ordering
+public async Task<IEnumerable<Player>> GetPlayersByTeamIdWithDetailsAsync(int teamId)
+{
+    Expression<Func<Player, bool>> teamPredicate = player => player.TeamId == teaamId;
+
+    // Order by player name
+    Func<IQueryable<Player>, IOrderedQueryable<Player>> orderByName = query => query.OrderBy(p => p.Name);
+
+    // Include related Stats and Contract
+    return await _playerRepository.GetByPredicateAsync(
+        predicate: teamPredicate,
+        orderBy: orderByName,
+        skip: 0,
+        take: 100,
+        includes: new Expression<Func<Player, object>>[]
+        {
+            player => player.Stats,
+            player => player.Contract
+        }
+    );
+}
+```
+- This method is very flexible and can be used for any type of filtering condition that can be expressed as a LINQ expression. The predicate is type-safe and will be translated to SQL by Entity Framework Core.
+
+- This example retrieves players from a specific team, orders them by name, and includes their stats and contract information.
+- The `includes` parameter is an array of expressions that specify the related entities to include in the query. This allows for eager loading of related data, which can help reduce the number of database queries and improve performance when accessing related entities.
+- The `skip` and `take` parameters are used for pagination, allowing you to control how many records to skip and how many to take in the result set. This is useful for implementing paging in your application.
+- The `orderBy` parameter is a function that specifies how to order the results. In this case, it orders the players by their name in ascending order.
+- The `predicate` parameter is a LINQ expression that defines the condition to filter the players. In this case, it filters players by their team ID.
+- The `cancellationToken` parameter allows you to cancel the operation if needed, which is useful for long-running queries or when the user navigates away from the page.
+- The `tracking` parameter is a boolean that specifies whether the returned entities should be tracked by the context. If set to `false`, the entities will not be tracked, which can improve performance when you don't need to modify them.
+- The `asNoTracking` parameter is a boolean that specifies whether to use the `AsNoTracking` method for the query. If set to `true`, the entities will not be tracked by the context, which can improve performance when you don't need to modify them.
+- The `includes` parameter is an array of expressions that specify the related entities to include in the query. This allows for eager loading of related data, which can help reduce the number of database queries and improve performance when accessing related entities.

--- a/League.Server/Controllers/TeamsController.cs
+++ b/League.Server/Controllers/TeamsController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace League.Server.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class TeamsController : ControllerBase
+    {
+        private readonly ILogger<TeamsController> _logger;
+
+        public TeamsController(ILogger<TeamsController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetTeams")]
+        public IEnumerable<Team> Get()
+        {
+            return Enumerable
+                .Select(
+                    index =>
+                        new Team
+                        {
+                            Id = index,
+                            Name = $"Team {index}",
+                            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                        }
+                )
+                .ToArray();
+        }
+    }
+
+    public class Team
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+    }
+}

--- a/League.Server/DTOs/ConferenceDto.cs
+++ b/League.Server/DTOs/ConferenceDto.cs
@@ -1,0 +1,33 @@
+namespace League.Server.DTOs
+{
+    /// <summary>
+    /// Data Transfer Object representing a conference in the league
+    /// </summary>
+    public class ConferenceDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the conference
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the league this conference belongs to
+        /// </summary>
+        public int LeagueId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full name of the conference
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the abbreviated name of the conference
+        /// </summary>
+        public string? Abbreviation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of divisions within this conference
+        /// </summary>
+        public List<DivisionDto> Divisions { get; set; } = [];
+    }
+}

--- a/League.Server/DTOs/DivisionDto.cs
+++ b/League.Server/DTOs/DivisionDto.cs
@@ -1,0 +1,33 @@
+namespace League.Server.DTOs
+{
+    /// <summary>
+    /// Data Transfer Object representing a division within a conference
+    /// </summary>
+    public class DivisionDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the division
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the conference this division belongs to
+        /// </summary>
+        public int ConferenceId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full name of the division
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the abbreviated name of the division
+        /// </summary>
+        public string? Abbreviation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of teams in this division
+        /// </summary>
+        public List<TeamDto> Teams { get; set; } = [];
+    }
+}

--- a/League.Server/DTOs/LeagueDto.cs
+++ b/League.Server/DTOs/LeagueDto.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace League.Server.DTOs
+{
+    /// <summary>
+    /// Data Transfer Object representing a league organization
+    /// </summary>
+    public class LeagueDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the league entity
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the league's business identifier
+        /// </summary>
+        public int LeagueId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full name of the league
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the abbreviated name of the league
+        /// </summary>
+        public string? Abbreviation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of conferences in this league
+        /// </summary>
+        public List<ConferenceDto> Conferences { get; set; } = [];
+    }
+}

--- a/League.Server/DTOs/PlayerDto.cs
+++ b/League.Server/DTOs/PlayerDto.cs
@@ -1,0 +1,98 @@
+namespace League.Server.DTOs
+{
+    /// <summary>
+    /// Data Transfer Object representing a player in the league
+    /// </summary>
+    public class PlayerDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the player
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the team this player belongs to
+        /// </summary>
+        public int TeamId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's jersey number
+        /// </summary>
+        public int Number { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's position on the team
+        /// </summary>
+        public string? Position { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's full name
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's height in inches
+        /// </summary>
+        public int? Height { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's weight in pounds
+        /// </summary>
+        public int? Weight { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's age
+        /// </summary>
+        public int? Age { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's birth date
+        /// </summary>
+        public DateTime? BirthDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's experience level in the league
+        /// </summary>
+        public string? Experience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the year the player was drafted
+        /// </summary>
+        public int? DraftYear { get; set; }
+
+        /// <summary>
+        /// Gets or sets the round in which the player was drafted
+        /// </summary>
+        public int? DraftRound { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pick number within the draft round
+        /// </summary>
+        public int? DraftPick { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's college or university
+        /// </summary>
+        public string? College { get; set; }
+
+        /// <summary>
+        /// Gets or sets the state where the player's college is located
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's rank within their position
+        /// </summary>
+        public int? Rank { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's overall rating
+        /// </summary>
+        public int? Rating { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's depth chart position
+        /// </summary>
+        public int? Depth { get; set; }
+    }
+}

--- a/League.Server/DTOs/TeamDto.cs
+++ b/League.Server/DTOs/TeamDto.cs
@@ -1,0 +1,103 @@
+namespace League.Server.DTOs
+{
+    /// <summary>
+    /// Data Transfer Object representing a team in the league
+    /// </summary>
+    public class TeamDto
+    {
+        /// <summary>
+        /// Gets or sets the unique identifier for the team
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the division this team belongs to
+        /// </summary>
+        public int DivisionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team's location (city or region)
+        /// </summary>
+        public string? Location { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team's name
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the team's abbreviated name
+        /// </summary>
+        public string? Abbreviation { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of games won
+        /// </summary>
+        public int Win { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of games lost
+        /// </summary>
+        public int Loss { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of games tied
+        /// </summary>
+        public int Tie { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total points scored by the team
+        /// </summary>
+        public int PointsFor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total points scored against the team
+        /// </summary>
+        public int PointsAgainst { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the team's home stadium
+        /// </summary>
+        public string? Stadium { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's seating capacity
+        /// </summary>
+        public int Capacity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's street address
+        /// </summary>
+        public string? Address { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's city location
+        /// </summary>
+        public string? City { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's state location
+        /// </summary>
+        public string? State { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's ZIP code
+        /// </summary>
+        public string? Zip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's latitude coordinate
+        /// </summary>
+        public double Latitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stadium's longitude coordinate
+        /// </summary>
+        public double Longitude { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of players on the team
+        /// </summary>
+        public List<PlayerDto> Players { get; set; } = [];
+    }
+}

--- a/League.Server/Data/DbInitializer.cs
+++ b/League.Server/Data/DbInitializer.cs
@@ -4,8 +4,7 @@ namespace League.Server.Data
 {
     public static class DbInitializer
     {
-
-        public static void Initialize(LeagueContext context)
+        public static void Initialize(LeagueDbContext context)
         {
             Console.WriteLine("Initializing Database...");
 
@@ -15,7 +14,7 @@ namespace League.Server.Data
             Console.WriteLine("context.Database.EnsureCreated()...");
 
             // Look for any Teams.
-            if(context.Teams.Any())
+            if (context.Teams.Any())
             {
                 Console.WriteLine("Teams exist...");
                 return; // DB has been seeded
@@ -32,7 +31,7 @@ namespace League.Server.Data
                 },
             };
 
-            foreach(var s in Leagues)
+            foreach (var s in Leagues)
             {
                 context.Leagues.Add(s);
             }
@@ -56,7 +55,7 @@ namespace League.Server.Data
                 }
             };
 
-            foreach(Conference c in Conferences)
+            foreach (Conference c in Conferences)
             {
                 context.Conferences.Add(c);
             }
@@ -45889,7 +45888,6 @@ namespace League.Server.Data
 
             context.Players.AddRange(Players);
             context.SaveChanges();
-
         }
     }
 }

--- a/League.Server/Data/LeagueDbContext.cs
+++ b/League.Server/Data/LeagueDbContext.cs
@@ -3,9 +3,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace League.Server.Data
 {
-    public class LeagueContext : DbContext
+    public class LeagueDbContext : DbContext
     {
-        public LeagueContext(DbContextOptions<LeagueContext> options)
+        public LeagueDbContext(DbContextOptions<LeagueDbContext> options)
             : base(options) { }
 
         public DbSet<Models.League> Leagues { get; set; }

--- a/League.Server/Data/Repositories/ConferenceRepository.cs
+++ b/League.Server/Data/Repositories/ConferenceRepository.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Repository for managing conference data in the database
+    /// </summary>
+    public class ConferenceRepository : GenericRepository<Conference>, IConferenceRepository
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<Conference> _conferences;
+        private readonly ILogger<ConferenceRepository> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConferenceRepository"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public ConferenceRepository(LeagueDbContext context, ILogger<ConferenceRepository> logger)
+            : base(context, logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _conferences = context.Set<Conference>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets conferences belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of conferences in the specified league</returns>
+        public async Task<IEnumerable<Conference>> GetConferencesByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching conferences by League ID: {LeagueId}", leagueId);
+
+            return await _conferences
+                .AsNoTracking()
+                .Where(c => c.LeagueId == leagueId)
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/League.Server/Data/Repositories/DivisionRepository.cs
+++ b/League.Server/Data/Repositories/DivisionRepository.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Repository for managing division data in the database
+    /// </summary>
+    public class DivisionRepository : GenericRepository<Division>, IDivisionRepository
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<Division> _divisions;
+        private readonly ILogger<DivisionRepository> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DivisionRepository"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public DivisionRepository(LeagueDbContext context, ILogger<DivisionRepository> logger)
+            : base(context, logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _divisions = context.Set<Division>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets divisions belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of divisions in the specified league</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when the league is not found</exception>
+        public async Task<IEnumerable<Division>> GetDivisionsByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching divisions by League ID: {LeagueId}", leagueId);
+            var league =
+                await _context
+                    .Leagues
+                    .Include(league => league.Conferences)
+                    .ThenInclude(conference => conference.Divisions)
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(league => league.Id == leagueId, cancellationToken)
+                ?? throw new KeyNotFoundException($"League with ID {leagueId} not found.");
+
+            return league?.Conferences.SelectMany(c => c.Divisions) ?? [];
+        }
+
+        /// <summary>
+        /// Gets divisions belonging to a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of divisions in the specified conference</returns>
+        public async Task<IEnumerable<Division>> GetDivisionsByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching divisions by Conference ID: {ConferenceId}", conferenceId);
+
+            return await _divisions
+                .AsNoTracking()
+                .Where(d => d.ConferenceId == conferenceId)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets the division for a specific team
+        /// </summary>
+        /// <param name="teamId">The ID of the team</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>The division the team belongs to</returns>
+        /// <exception cref="KeyNotFoundException">Thrown when the team or its division is not found</exception>
+        public async Task<Division> GetDivisionByTeamIdAsync(
+            int teamId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching division by Team ID: {TeamId}", teamId);
+
+            var team = await _context
+                .Teams
+                .Include(team => team.Division)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(team => team.Id == teamId, cancellationToken);
+
+            if (team is null)
+            {
+                _logger.LogWarning("Team with ID {TeamId} not found.", teamId);
+                throw new KeyNotFoundException($"Team with ID {teamId} not found.");
+            }
+            else if (team.Division is null)
+            {
+                _logger.LogWarning("Division for Team ID {TeamId} not found.", teamId);
+                throw new KeyNotFoundException($"Division for Team with ID {teamId} not found.");
+            }
+
+            return team.Division;
+        }
+    }
+}

--- a/League.Server/Data/Repositories/GenericRepository.cs
+++ b/League.Server/Data/Repositories/GenericRepository.cs
@@ -1,0 +1,439 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Data;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using League.Server.Models.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Generic repository implementation that provides common data access operations for any entity
+    /// </summary>
+    /// <typeparam name="T">The entity type for which the repository is created</typeparam>
+    public class GenericRepository<T> : IGenericRepository<T>
+        where T : class
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<T> _dbSet;
+        private readonly ILogger<GenericRepository<T>> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericRepository{T}"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public GenericRepository(LeagueDbContext context, ILogger<GenericRepository<T>> logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _dbSet = context.Set<T>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets all entities of type T
+        /// </summary>
+        /// <returns>A collection of all entities</returns>
+        public async Task<IEnumerable<T>> GetAllAsync()
+        {
+            _logger.LogInformation("Fetching all records of type {EntityType}", typeof(T).Name);
+            return await _dbSet.AsNoTracking().ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets an entity by its ID
+        /// </summary>
+        /// <param name="id">The entity ID</param>
+        /// <returns>The entity if found; otherwise, null</returns>
+        public async Task<T?> GetByIdAsync(int id)
+        {
+            _logger.LogInformation(
+                "Fetching record with ID {Id} of type {EntityType}",
+                id,
+                typeof(T).Name
+            );
+            return await _dbSet.FindAsync(id);
+        }
+
+        /// <summary>
+        /// Finds entities that match the specified predicate
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <returns>A collection of matching entities</returns>
+        public async Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate)
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with condition: {Condition}",
+                typeof(T).Name,
+                predicate
+            );
+            return await _dbSet.Where(predicate).AsNoTracking().ToListAsync();
+        }
+
+        /// <summary>
+        /// Adds a new entity to the database
+        /// </summary>
+        /// <param name="entity">The entity to add</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+        {
+            if (entity is null)
+            {
+                _logger.LogWarning("Attempted to add a null entity.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Adding a new record of type {EntityType}: {Entity}",
+                typeof(T).Name,
+                entity
+            );
+            await _dbSet.AddAsync(entity, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates an existing entity in the database
+        /// </summary>
+        /// <param name="entity">The entity to update</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        public async Task UpdateAsync(T entity, CancellationToken cancellationToken = default)
+        {
+            if (entity is null)
+            {
+                _logger.LogWarning("Attempted to update a null entity.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Updating a record of type {EntityType}: {Entity}",
+                typeof(T).Name,
+                entity
+            );
+            _dbSet.Update(entity);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Deletes an entity from the database
+        /// </summary>
+        /// <param name="entity">The entity to delete</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        public async Task DeleteAsync(T entity, CancellationToken cancellationToken = default)
+        {
+            if (entity is null)
+            {
+                _logger.LogWarning("Attempted to delete a null entity.");
+                return;
+            }
+
+            _logger.LogInformation(
+                "Deleting record of type {EntityType}: {Entity}",
+                typeof(T).Name,
+                entity
+            );
+
+            if (entity is ISoftDeletable softDeletableEntity)
+            {
+                _logger.LogDebug(
+                    "Soft deleting record of type {EntityType}: {Entity}",
+                    typeof(T).Name,
+                    entity
+                );
+
+                softDeletableEntity.IsDeleted = true;
+                softDeletableEntity.DeletedAt = DateTime.UtcNow;
+                _dbSet.Update(entity);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Hard deleting record of type {EntityType}: {Entity}",
+                    typeof(T).Name,
+                    entity
+                );
+                _dbSet.Remove(entity);
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Deletes an entity by ID, using soft delete if the entity implements ISoftDeletable
+        /// </summary>
+        /// <param name="id">The ID of the entity to delete</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        public async Task DeleteByIdAsync(int id, CancellationToken cancellationToken = default)
+        {
+            _logger.LogInformation(
+                "Deleting record with ID {Id} of type {EntityType}",
+                id,
+                typeof(T).Name
+            );
+
+            var entity = await GetByIdAsync(id);
+            if (entity is null)
+            {
+                _logger.LogWarning("Record with ID {Id} not found for deletion.", id);
+                return;
+            }
+
+            await DeleteAsync(entity, cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <returns>A collection of matching entities</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(Expression<Func<T, bool>> predicate)
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}",
+                typeof(T).Name,
+                predicate
+            );
+            return await _dbSet.Where(predicate).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with ordering
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <returns>A collection of matching entities</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate} and ordering",
+                typeof(T).Name,
+                predicate
+            );
+            return await orderBy(_dbSet.Where(predicate)).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination and ordering
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <returns>A collection of matching entities</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}, ordering, skipping {Skip}, taking {Take}",
+                typeof(T).Name,
+                predicate,
+                skip,
+                take
+            );
+            return await orderBy(_dbSet.Where(predicate)).Skip(skip).Take(take).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, and includes
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            params Expression<Func<T, object>>[] includes
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}, ordering, skipping {Skip}, taking {Take}",
+                typeof(T).Name,
+                predicate,
+                skip,
+                take
+            );
+
+            IQueryable<T> query = _dbSet.Where(predicate);
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
+
+            return await orderBy(query).Skip(skip).Take(take).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, includes, and tracking options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            params Expression<Func<T, object>>[] includes
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}, ordering, skipping {Skip}, taking {Take}",
+                typeof(T).Name,
+                predicate,
+                skip,
+                take
+            );
+
+            IQueryable<T> query = disableTracking ? _dbSet.AsNoTracking() : _dbSet;
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
+
+            return await orderBy(query).Where(predicate).Skip(skip).Take(take).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, includes, and tracking options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="asNoTracking">Whether to use AsNoTracking</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            bool asNoTracking,
+            params Expression<Func<T, object>>[] includes
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}, ordering, skipping {Skip}, taking {Take}",
+                typeof(T).Name,
+                predicate,
+                skip,
+                take
+            );
+
+            IQueryable<T> query = _dbSet;
+
+            if (disableTracking || asNoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
+
+            return await orderBy(query).Where(predicate).Skip(skip).Take(take).ToListAsync();
+        }
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with full filtering options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="asNoTracking">Whether to use AsNoTracking</param>
+        /// <param name="includeDeleted">Whether to include soft-deleted records</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        public async Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            bool asNoTracking,
+            bool includeDeleted,
+            params Expression<Func<T, object>>[] includes
+        )
+        {
+            _logger.LogInformation(
+                "Fetching records of type {EntityType} with predicate: {Predicate}, ordering, skipping {Skip}, taking {Take}, includeDeleted: {IncludeDeleted}",
+                typeof(T).Name,
+                predicate,
+                skip,
+                take,
+                includeDeleted
+            );
+
+            if (predicate is null)
+            {
+                _logger.LogWarning("Predicate is null, returning empty list.");
+                return Array.Empty<T>();
+            }
+
+            IQueryable<T> query = _dbSet;
+
+            if (disableTracking || asNoTracking)
+            {
+                query = query.AsNoTracking();
+            }
+
+            query = ApplySoftDeleteFilter(query, includeDeleted);
+
+            foreach (var include in includes)
+            {
+                query = query.Include(include);
+            }
+
+            return await orderBy(query).Where(predicate).Skip(skip).Take(take).ToListAsync();
+        }
+
+        /// <summary>
+        /// Applies soft delete filtering to a query if applicable
+        /// </summary>
+        /// <param name="query">The query to filter</param>
+        /// <param name="includeDeleted">Whether to include soft-deleted records</param>
+        /// <returns>The filtered query</returns>
+        private IQueryable<T> ApplySoftDeleteFilter(IQueryable<T> query, bool includeDeleted)
+        {
+            if (!includeDeleted && typeof(ISoftDeletable).IsAssignableFrom(typeof(T)))
+            {
+                query = query.Where(x => !((ISoftDeletable)x).IsDeleted);
+            }
+
+            return query;
+        }
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/IConferenceRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/IConferenceRepository.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Models;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interface for conference repository operations
+    /// </summary>
+    public interface IConferenceRepository
+    {
+        /// <summary>
+        /// Gets conferences belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of conferences in the specified league</returns>
+        Task<IEnumerable<Conference>> GetConferencesByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/IDivisionRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/IDivisionRepository.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Models;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interface for division repository operations
+    /// </summary>
+    public interface IDivisionRepository
+    {
+        /// <summary>
+        /// Gets divisions belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of divisions in the specified league</returns>
+        Task<IEnumerable<Division>> GetDivisionsByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets divisions belonging to a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of divisions in the specified conference</returns>
+        Task<IEnumerable<Division>> GetDivisionsByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets the division for a specific team
+        /// </summary>
+        /// <param name="teamId">The ID of the team</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>The division the team belongs to</returns>
+        Task<Division> GetDivisionByTeamIdAsync(
+            int teamId,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/IGenericRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/IGenericRepository.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Generic repository interface providing common data access operations for any entity
+    /// </summary>
+    /// <typeparam name="T">The entity type for which the repository is created</typeparam>
+    public interface IGenericRepository<T>
+        where T : class
+    {
+        /// <summary>
+        /// Gets all entities of type T
+        /// </summary>
+        /// <returns>A collection of all entities</returns>
+        Task<IEnumerable<T>> GetAllAsync();
+
+        /// <summary>
+        /// Gets an entity by its ID
+        /// </summary>
+        /// <param name="id">The entity ID</param>
+        /// <returns>The entity if found; otherwise, null</returns>
+        Task<T?> GetByIdAsync(int id);
+
+        /// <summary>
+        /// Finds entities that match the specified predicate
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <returns>A collection of matching entities</returns>
+        Task<IEnumerable<T>> FindAsync(Expression<Func<T, bool>> predicate);
+
+        /// <summary>
+        /// Adds a new entity to the database
+        /// </summary>
+        /// <param name="entity">The entity to add</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        Task AddAsync(T entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates an existing entity in the database
+        /// </summary>
+        /// <param name="entity">The entity to update</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        Task UpdateAsync(T entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes an entity from the database
+        /// </summary>
+        /// <param name="entity">The entity to delete</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        Task DeleteAsync(T entity, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes an entity by ID, using soft delete if the entity implements ISoftDeletable
+        /// </summary>
+        /// <param name="id">The ID of the entity to delete</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A task representing the asynchronous operation</returns>
+        Task DeleteByIdAsync(int id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets entities that match the specified predicate
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <returns>A collection of matching entities</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(Expression<Func<T, bool>> predicate);
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with ordering
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <returns>A collection of matching entities</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy
+        );
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination and ordering
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <returns>A collection of matching entities</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take
+        );
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, and includes
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            params Expression<Func<T, object>>[] includes
+        );
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, includes, and tracking options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            params Expression<Func<T, object>>[] includes
+        );
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with pagination, ordering, includes, and tracking options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="asNoTracking">Whether to use AsNoTracking</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            bool asNoTracking,
+            params Expression<Func<T, object>>[] includes
+        );
+
+        /// <summary>
+        /// Gets entities that match the specified predicate with full filtering options
+        /// </summary>
+        /// <param name="predicate">The condition to apply</param>
+        /// <param name="orderBy">The ordering function</param>
+        /// <param name="skip">Number of records to skip</param>
+        /// <param name="take">Number of records to take</param>
+        /// <param name="disableTracking">Whether to disable change tracking</param>
+        /// <param name="asNoTracking">Whether to use AsNoTracking</param>
+        /// <param name="includeDeleted">Whether to include soft-deleted records</param>
+        /// <param name="includes">Related entities to include</param>
+        /// <returns>A collection of matching entities with their related data</returns>
+        Task<IEnumerable<T>> GetByPredicateAsync(
+            Expression<Func<T, bool>> predicate,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy,
+            int skip,
+            int take,
+            bool disableTracking,
+            bool asNoTracking,
+            bool includeDeleted,
+            params Expression<Func<T, object>>[] includes
+        );
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/ILeagueRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/ILeagueRepository.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using League.Server.Models;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interface for league repository operations
+    /// </summary>
+    public interface ILeagueRepository
+    {
+        /// <summary>
+        /// Gets leagues containing the specified name
+        /// </summary>
+        /// <param name="name">The name to search for</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of leagues matching the search criteria</returns>
+        Task<IEnumerable<Models.League>> GetLeaguesByNameAsync(
+            string name,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/IPlayerRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/IPlayerRepository.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Models;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interface for player repository operations
+    /// </summary>
+    public interface IPlayerRepository
+    {
+        /// <summary>
+        /// Gets players by their team ID
+        /// </summary>
+        /// <param name="teamId">The ID of the team</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players belonging to the specified team</returns>
+        Task<IEnumerable<Player>> GetPlayersByTeamIdAsync(
+            int teamId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets players from a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified league</returns>
+        Task<IEnumerable<Player>> GetPlayersByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets players from a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified conference</returns>
+        Task<IEnumerable<Player>> GetPlayersByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets players from a specific division
+        /// </summary>
+        /// <param name="divisionId">The ID of the division</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified division</returns>
+        Task<IEnumerable<Player>> GetPlayersByDivisionIdAsync(
+            int divisionId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets players by their position
+        /// </summary>
+        /// <param name="position">The position to filter by (e.g., QB, RB, WR)</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players with the specified position</returns>
+        Task<IEnumerable<Player>> GetPlayersByPositionAsync(
+            string position,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/League.Server/Data/Repositories/Interfaces/ITeamRepository.cs
+++ b/League.Server/Data/Repositories/Interfaces/ITeamRepository.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Models;
+
+namespace League.Server.Data.Repositories.Interfaces
+{
+    /// <summary>
+    /// Interface for team repository operations
+    /// </summary>
+    public interface ITeamRepository
+    {
+        /// <summary>
+        /// Gets teams belonging to a specific division
+        /// </summary>
+        /// <param name="divisionId">The ID of the division</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified division</returns>
+        Task<IEnumerable<Team>> GetTeamsByDivisionIdAsync(
+            int divisionId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets teams belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified league</returns>
+        Task<IEnumerable<Team>> GetTeamsByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Gets teams belonging to a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified conference</returns>
+        Task<IEnumerable<Team>> GetTeamsByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        );
+    }
+}

--- a/League.Server/Data/Repositories/LeagueRepository.cs
+++ b/League.Server/Data/Repositories/LeagueRepository.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using League.Server.Data;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Repository for managing league data in the database
+    /// </summary>
+    public class LeagueRepository : GenericRepository<Models.League>, ILeagueRepository
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<Models.League> _leagues;
+        private readonly ILogger<LeagueRepository> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LeagueRepository"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public LeagueRepository(LeagueDbContext context, ILogger<LeagueRepository> logger)
+            : base(context, logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _leagues = context.Set<Models.League>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets leagues containing the specified name
+        /// </summary>
+        /// <param name="name">The name to search for</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of leagues matching the search criteria</returns>
+        public async Task<IEnumerable<Models.League>> GetLeaguesByNameAsync(
+            string name,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching leagues by name: {Name}", name);
+            return await _leagues
+                .AsNoTracking()
+                .Where(league => league.Name!.Contains(name))
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/League.Server/Data/Repositories/PlayerRepository.cs
+++ b/League.Server/Data/Repositories/PlayerRepository.cs
@@ -1,0 +1,137 @@
+using System.Linq.Expressions;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Repository for managing player data in the database
+    /// </summary>
+    public class PlayerRepository : GenericRepository<Player>, IPlayerRepository
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<Player> _players;
+        private readonly ILogger<PlayerRepository> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PlayerRepository"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public PlayerRepository(LeagueDbContext context, ILogger<PlayerRepository> logger)
+            : base(context, logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _players = context.Set<Player>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets players by their team ID
+        /// </summary>
+        /// <param name="teamId">The ID of the team</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players belonging to the specified team</returns>
+        public async Task<IEnumerable<Player>> GetPlayersByTeamIdAsync(
+            int teamId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Getting players for team ID {TeamId}...", teamId);
+            Expression<Func<Player, bool>> predicate = player => player.TeamId == teamId;
+            return await GetByPredicateAsync(predicate);
+        }
+
+        /// <summary>
+        /// Gets players from a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified league</returns>
+        public async Task<IEnumerable<Player>> GetPlayersByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching players by League ID: {LeagueId}", leagueId);
+
+            return await _players
+                .Include(p => p.Team)
+                .ThenInclude(t => t!.Division)
+                .ThenInclude(d => d!.Conference)
+                .AsNoTracking()
+                .Where(
+                    p =>
+                        p.Team != null
+                        && p.Team.Division != null
+                        && p.Team.Division.Conference != null
+                        && p.Team.Division.Conference.LeagueId == leagueId
+                )
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets players from a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified conference</returns>
+        public async Task<IEnumerable<Player>> GetPlayersByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching players by Conference ID: {ConferenceId}", conferenceId);
+
+            return await _players
+                .Include(p => p.Team)
+                .ThenInclude(t => t!.Division)
+                .AsNoTracking()
+                .Where(
+                    p =>
+                        p.Team != null
+                        && p.Team.Division != null
+                        && p.Team.Division.ConferenceId == conferenceId
+                )
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets players from a specific division
+        /// </summary>
+        /// <param name="divisionId">The ID of the division</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players from the specified division</returns>
+        public async Task<IEnumerable<Player>> GetPlayersByDivisionIdAsync(
+            int divisionId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching players by Division ID: {DivisionId}", divisionId);
+
+            return await _players
+                .Include(p => p.Team)
+                .AsNoTracking()
+                .Where(p => p.Team != null && p.Team.DivisionId == divisionId)
+                .ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// Gets players by their position
+        /// </summary>
+        /// <param name="position">The position to filter by (e.g., QB, RB, WR)</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of players with the specified position</returns>
+        public async Task<IEnumerable<Player>> GetPlayersByPositionAsync(
+            string position,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Getting players by position: {Position}", position);
+            Expression<Func<Player, bool>> predicate = player => player.Position == position;
+            return await GetByPredicateAsync(predicate);
+        }
+    }
+}

--- a/League.Server/Data/Repositories/TeamRepository.cs
+++ b/League.Server/Data/Repositories/TeamRepository.cs
@@ -1,0 +1,95 @@
+using System.Linq.Expressions;
+using League.Server.Data.Repositories.Interfaces;
+using League.Server.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace League.Server.Data.Repositories
+{
+    /// <summary>
+    /// Repository for managing team data in the database
+    /// </summary>
+    public class TeamRepository : GenericRepository<Team>, ITeamRepository
+    {
+        private readonly LeagueDbContext _context;
+        private readonly DbSet<Team> _teams;
+        private readonly ILogger<TeamRepository> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TeamRepository"/> class
+        /// </summary>
+        /// <param name="context">The database context</param>
+        /// <param name="logger">The logger instance</param>
+        /// <exception cref="ArgumentNullException">Thrown when context or logger is null</exception>
+        public TeamRepository(LeagueDbContext context, ILogger<TeamRepository> logger)
+            : base(context, logger)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _teams = context.Set<Team>();
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Gets teams belonging to a specific division
+        /// </summary>
+        /// <param name="divisionId">The ID of the division</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified division</returns>
+        public async Task<IEnumerable<Team>> GetTeamsByDivisionIdAsync(
+            int divisionId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching teams by Division ID: {DivisionId}", divisionId);
+            Expression<Func<Team, bool>> predicate = team => team.DivisionId == divisionId;
+            return await GetByPredicateAsync(predicate);
+        }
+
+        /// <summary>
+        /// Gets teams belonging to a specific league
+        /// </summary>
+        /// <param name="leagueId">The ID of the league</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified league</returns>
+        public async Task<IEnumerable<Team>> GetTeamsByLeagueIdAsync(
+            int leagueId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching teams by League ID: {LeagueId}", leagueId);
+            return await _teams
+                    .Include(team => team.Division)
+                    .ThenInclude(division => division!.Conference)
+                    // .ThenInclude(conference => conference!.League)
+                    .AsNoTracking()
+                    .Where(
+                        team =>
+                            team.Division != null
+                            && team.Division.Conference != null
+                            && team.Division.Conference.LeagueId == leagueId
+                    )
+                    .ToListAsync(cancellationToken) ?? [];
+        }
+
+        /// <summary>
+        /// Gets teams belonging to a specific conference
+        /// </summary>
+        /// <param name="conferenceId">The ID of the conference</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation</param>
+        /// <returns>A collection of teams in the specified conference</returns>
+        public async Task<IEnumerable<Team>> GetTeamsByConferenceIdAsync(
+            int conferenceId,
+            CancellationToken cancellationToken = default
+        )
+        {
+            _logger.LogDebug("Fetching teams by Conference ID: {ConferenceId}", conferenceId);
+
+            return await _teams
+                    .Include(team => team.Division)
+                    .AsNoTracking()
+                    .Where(
+                        team => team.Division != null && team.Division.ConferenceId == conferenceId
+                    )
+                    .ToListAsync(cancellationToken) ?? [];
+        }
+    }
+}

--- a/League.Server/League.Server.csproj
+++ b/League.Server/League.Server.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
       <Version>9.*-*</Version>

--- a/League.Server/Mappings/MappingProfile.cs
+++ b/League.Server/Mappings/MappingProfile.cs
@@ -1,0 +1,44 @@
+using AutoMapper;
+using League.Server.DTOs;
+using League.Server.Models;
+
+namespace League.Server.Mappings
+{
+    /// <summary>
+    /// AutoMapper profile that defines the mapping configurations between domain models and DTOs
+    /// </summary>
+    public class MappingProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the MappingProfile class and configures all the model to DTO mappings
+        /// </summary>
+        public MappingProfile()
+        {
+            // League mappings
+            CreateMap<Models.League, LeagueDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Conferences, opt => opt.Ignore()); // Ignore Conferences property during mapping
+
+            // Conference mappings
+            CreateMap<Conference, ConferenceDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Divisions, opt => opt.Ignore()); // Ignore Divisions property during mapping
+
+            // Division mappings
+            CreateMap<Division, DivisionDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Teams, opt => opt.Ignore()); // Ignore Teams property during mapping
+
+            // Team mappings
+            CreateMap<Team, TeamDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Players, opt => opt.Ignore());
+
+            // Player mappings
+            CreateMap<Player, PlayerDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Team, opt => opt.Ignore()) // Ignore Team property during mapping
+                .ForMember(dest => dest.TeamId, opt => opt.Ignore()); // Ignore TeamId property during mapping
+        }
+    }
+}

--- a/League.Server/Migrations/20250425023047_InitialMigration.Designer.cs
+++ b/League.Server/Migrations/20250425023047_InitialMigration.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace League.Server.Migrations
 {
-    [DbContext(typeof(LeagueContext))]
+    [DbContext(typeof(LeagueDbContext))]
     [Migration("20250425023047_InitialMigration")]
     partial class InitialMigration
     {

--- a/League.Server/Migrations/20250425023535_InitialMigration1.Designer.cs
+++ b/League.Server/Migrations/20250425023535_InitialMigration1.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace League.Server.Migrations
 {
-    [DbContext(typeof(LeagueContext))]
+    [DbContext(typeof(LeagueDbContext))]
     [Migration("20250425023535_InitialMigration1")]
     partial class InitialMigration1
     {

--- a/League.Server/Migrations/LeagueContextModelSnapshot.cs
+++ b/League.Server/Migrations/LeagueContextModelSnapshot.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace League.Server.Migrations
 {
-    [DbContext(typeof(LeagueContext))]
+    [DbContext(typeof(LeagueDbContext))]
     partial class LeagueContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/League.Server/Models/Division.cs
+++ b/League.Server/Models/Division.cs
@@ -35,12 +35,12 @@ namespace League.Server.Models
         /// Navigation property to the parent conference
         /// </summary>
         [ForeignKey("ConferenceId")]
-        public Conference Conference { get; set; }
+        public Conference? Conference { get; set; }
 
         /// <summary>
         /// Collection of teams in this division
         /// </summary>
         [InverseProperty("Division")]
-        public List<Team> Teams { get; set; }
+        public List<Team>? Teams { get; set; }
     }
 }

--- a/League.Server/Models/Interfaces/ISoftDeletable.cs
+++ b/League.Server/Models/Interfaces/ISoftDeletable.cs
@@ -1,0 +1,10 @@
+namespace League.Server.Models.Interfaces
+{
+    public interface ISoftDeletable
+    {
+        bool IsDeleted { get; set; }
+        DateTime? DeletedAt { get; set; }
+        string? DeletedReason { get; set; }
+        string? DeletedByUserId { get; set; }
+    }
+}

--- a/League.Server/Models/Player.cs
+++ b/League.Server/Models/Player.cs
@@ -129,6 +129,6 @@ namespace League.Server.Models
         /// Navigation property to the player's team
         /// </summary>
         [ForeignKey("TeamId")]
-        public Team Team { get; set; }
+        public Team? Team { get; set; }
     }
 }

--- a/League.Server/Models/Team.cs
+++ b/League.Server/Models/Team.cs
@@ -122,12 +122,12 @@ namespace League.Server.Models
         /// Navigation property to the division this team belongs to
         /// </summary>
         [ForeignKey("DivisionId")]
-        public Division Division { get; set; }
+        public Division? Division { get; set; }
 
         /// <summary>
         /// Collection of players on this team
         /// </summary>
         [InverseProperty("Team")]
-        public ICollection<Player> Players { get; set; }
+        public ICollection<Player>? Players { get; set; }
     }
 }

--- a/League.Server/Program.cs
+++ b/League.Server/Program.cs
@@ -4,17 +4,17 @@ using Microsoft.EntityFrameworkCore;
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
 
-
 // Add services to the container.
 services.AddDistributedMemoryCache();
-services.AddSession(options => {
+services.AddSession(options =>
+{
     options.IdleTimeout = TimeSpan.FromMinutes(30);
     options.Cookie.HttpOnly = true;
     options.Cookie.IsEssential = true;
 });
 
-services.AddDbContext<LeagueContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DatabaseConnection"))
+services.AddDbContext<LeagueDbContext>(
+    options => options.UseSqlServer(builder.Configuration.GetConnectionString("DatabaseConnection"))
 );
 
 services.AddControllers();
@@ -31,9 +31,14 @@ app.UseDefaultFiles();
 app.MapStaticAssets();
 
 // Configure the HTTP request pipeline.
-if(app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
+}
+else
+{
+    app.UseExceptionHandler("/error");
+    app.UseHsts();
 }
 
 app.UseHttpsRedirection();
@@ -50,13 +55,13 @@ static void CreateDbIfNotExists(IHost host)
 {
     using var scope = host.Services.CreateScope();
     var services = scope.ServiceProvider;
-    var context = services.GetRequiredService<LeagueContext>();
+    var context = services.GetRequiredService<LeagueDbContext>();
 
     try
     {
         DbInitializer.Initialize(context);
     }
-    catch(Exception ex)
+    catch (Exception ex)
     {
         throw new Exception($"An error occurred creating the DB: {ex.Message}", ex);
     }

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,102 @@
+# ToDo List for the League project
+
+This is a ToDo list for the League project, which includes tasks related to the database schema, models, and other functionalities. Each task is categorized and includes a brief description of what needs to be done.
+
+---
+
+## Base Class for Models
+
+Add a base class `BaseEntity` for all models in the League project. This class should include properties for `created_date` and `updated_date`. All models should inherit from this base class to ensure consistency across the application.
+This will help in tracking the creation and modification dates of each entity in the database and will automatically update these fields when a record is created or modified.
+
+### Base Class for Models - Tasks:
+
+1. Create a base class for models named `BaseEntity` in the League project
+   - This class should include properties for `CreatedDate` and `UpdatedDate`.
+   - Ensure that all models in the project inherit from this base class.
+   - Implement logic to automatically set the `CreatedDate` when a record is created and update
+     the `UpdatedDate` when a record is modified.
+2. Ensure all models inherit from the base class
+3. Update the database schema to include `CreatedDate` and `UpdatedDate` fields in all models
+4. Create a migration to apply changes to the database
+5. Review and test the changes to ensure proper functionality.
+6. Update the documentation to reflect the changes made to the models and database schema.
+7. Ensure that the `CreatedDate` and `UpdatedDate` fields are properly indexed for performance
+    optimization.
+8. Create unit tests for the base class and ensure that the date fields are set correctly
+    during creation and modification.
+
+---
+
+## Implement `IGenericRepository` and `GenericRepository`
+
+Implement the `IGenericRepository` interface and the `GenericRepository` class to provide a generic way to interact with the database. This will allow for CRUD operations on any entity type without needing to create a specific repository for each entity.
+This will help in reducing code duplication and improving maintainability.
+
+## Soft Delete Functionality
+
+==This is Overkill==
+
+Implement soft delete functionality in the `GenericRepository` class. This will allow entities to be marked as deleted without actually removing them from the database. This is useful for maintaining data integrity and allowing for potential recovery of deleted records.
+This will involve adding a `IsDeleted` property to the base entity class and updating the repository methods to respect this property when querying for entities.
+
+### Soft Delete Functionality - Tasks:
+
+1. Create an interface `ISoftDeletable` with properties for tracking deletion information (already completed)
+    - Properties should include `IsDeleted`, `DeletedAt`, `DeletedReason`, and `DeletedByUserId`
+
+2. Update existing entity models to implement `ISoftDeletable` interface
+    - Modify all relevant entity classes to implement the interface
+    - Add the required properties to each model class
+
+```csharp
+// Example entity implementation
+public class Player : BaseEntity, ISoftDeletable
+{
+    // ... existing properties ...
+    public bool IsDeleted { get; set; } = false;
+    public DateTime? DeletedAt { get; set; }
+    public string? DeletedReason { get; set; }
+    public string? DeletedByUserId { get; set; }
+
+}
+
+3. Update database schema to include soft delete columns
+    - Add `IsDeleted`, `DeletedAt`, `DeletedReason`, and `DeletedByUserId` fields to relevant tables
+    - Create a migration to apply these changes to the database
+
+4. Update existing repository implementations
+    - Modify specific repositories like `PlayerRepository` to use soft delete functionality
+    - Replace direct removal operations with soft delete calls
+
+5. Update controllers and services to handle soft-deleted entities
+    - Add options to include or exclude soft-deleted items in queries
+    - Add functionality to restore soft-deleted items
+
+6. Create unit tests for soft delete functionality
+    - Test that entities are properly marked as deleted rather than removed
+    - Test that queries filter out soft-deleted entities by default
+    - Test restoration functionality
+
+7. Add UI components to display and manage soft-deleted entities
+    - Create views to see soft-deleted items
+    - Add restore functionality to the user interface
+
+8. Document the soft delete pattern for the project
+    - Update API documentation to include information about soft delete
+    - Document how to properly query including or excluding soft-deleted items
+
+
+### This implementation:
+
+- Adds soft delete functionality through ISoftDeletable interface
+- Modifies DeleteAsync to perform soft delete when applicable
+- Adds ApplySoftDeleteFilter helper method to filter out soft-deleted records
+- Updates logging to include the includeDeleted parameter
+- Properly handles the includeDeleted parameter in queries
+- Ensures that soft-deleted entities are excluded from default queries
+- Implements restoration functionality for soft-deleted entities
+
+---
+
+## Implement `IUnitOfWork` and `UnitOfWork`


### PR DESCRIPTION
- Added IConferenceRepository and its implementation for fetching conferences by league ID.
- Added IDivisionRepository with methods to retrieve divisions by league and conference IDs, and by team ID.
- Introduced IGenericRepository for generic CRUD operations across entities.
- Created ILeagueRepository for fetching leagues by name.
- Developed IPlayerRepository for retrieving players based on team, league, conference, division, and position.
- Established ITeamRepository for fetching teams by division, league, and conference.
- Implemented LeagueRepository and PlayerRepository with specific data access logic.
- Created TeamRepository for managing team data with appropriate methods.
- Added MappingProfile for AutoMapper configurations between models and DTOs.
- Introduced ISoftDeletable interface for soft delete functionality in models.
- Updated ToDo.md with tasks related to model base class, soft delete implementation, and repository patterns.